### PR TITLE
Correct URLs in example code

### DIFF
--- a/README
+++ b/README
@@ -54,8 +54,8 @@ GETTING STARTED
         my $oauth = OAuth::Cmdline::GoogleDrive->new(
             client_id     => "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
             client_secret => "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY",
-            login_uri     => "https://accounts.spotify.com/authorize",
-            token_uri     => "https://accounts.spotify.com/api/token",
+            login_uri     => "https://accounts.google.com/o/oauth2/auth",
+            token_uri     => "https://accounts.google.com/o/oauth2/token",
             scope         => "user-read-private",
         );
     

--- a/lib/OAuth/Cmdline.pm
+++ b/lib/OAuth/Cmdline.pm
@@ -324,8 +324,8 @@ Then, run the following script (the example uses the Spotify web service)
     my $oauth = OAuth::Cmdline::GoogleDrive->new(
         client_id     => "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
         client_secret => "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY",
-        login_uri     => "https://accounts.spotify.com/authorize",
-        token_uri     => "https://accounts.spotify.com/api/token",
+	login_uri     => "https://accounts.google.com/o/oauth2/auth",
+	token_uri     => "https://accounts.google.com/o/oauth2/token",
         scope         => "user-read-private",
     );
     


### PR DESCRIPTION
In the example in the README and the perldoc, the module imported is GoogleDrive but the URLs used are for spotify. Corrected this. 
