### PR TITLE
Added a module which allows a specific credential file

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,7 +2,7 @@
 Revision history for Perl extension OAuth::Cmdline
 
 {{$NEXT}}
-
+    - Added OAuth::Cmdline::CustomFile module to allow a specific credential file
     - Add basic Continuous Integration workflow
     - Convert distribution to use Dist::Zilla
     - Adjust dependencies list (need Perl >= 5.016 for Mojolicious)

--- a/lib/OAuth/Cmdline/CustomFile.pm
+++ b/lib/OAuth/Cmdline/CustomFile.pm
@@ -1,0 +1,42 @@
+###########################################
+package OAuth::Cmdline::CustomFile;
+###########################################
+use strict;
+use warnings;
+use MIME::Base64;
+use Moo;
+
+extends 'OAuth::Cmdline';
+
+has custom_file => ( is => "rw" );
+
+# VERSION
+# ABSTRACT: Use a custom cache file with  OAuth::Cmdline
+
+###########################################
+sub site {
+###########################################
+    return "custom-file";
+}
+
+###########################################
+sub cache_file_path {
+###########################################
+    my( $self ) = @_;
+
+    return $self->custom_file;
+}
+
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+    my $oauth = OAuth::Cmdline::CustomFile->new( custom_file => "<path>" );
+    $oauth->access_token();
+
+=head1 DESCRIPTION
+
+This class overrides the cache_file_path method of C<OAuth::Cmdline>
+and adds the custom_file attribute.


### PR DESCRIPTION
The current set of modules hardcode the location of the
file used to cache the credential for the service.  I added
OAuth::Cmdline::CustomFile so I could specify a specific
file instead.

(cherry picked from commit 49a64b5b9492d37503f9c90561002a06aa8c2f1a)
Signed-off-by: Nicolas R <nicolas@atoomic.org>