### PR TITLE
Throw more descriptive errors when getting a token

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,25 +2,28 @@
 Revision history for Perl extension OAuth::Cmdline
 
 {{$NEXT}}
+    - Throw more descriptive errors when getting a token
+    (thanks Tim Mullin)
     - Added OAuth::Cmdline::CustomFile module to allow a specific credential file
+    (thanks Tim Mullin)
     - Add basic Continuous Integration workflow
     - Convert distribution to use Dist::Zilla
     - Adjust dependencies list (need Perl >= 5.016 for Mojolicious)
     - Update MSOnline tests to account for changes to API URL and request format
-    ( thanks Ian Gibbs)
+    (thanks Ian Gibbs)
     - Update documentation
     - Adjust MANIFEST
-    ( thanks Szymon Nieznański)
+    (thanks Szymon Nieznański)
     - Add mandatory resource param to msonline token initialiser
-    ( thanks Ian Gibbs)
+    (thanks Ian Gibbs)
     - Add tests for MSOnline
-    ( thanks Ian Gibbs)
+    (thanks Ian Gibbs)
     - Add some "no-op" token methods
-    ( thanks Ian Gibbs)
+    (thanks Ian Gibbs)
     - Fix incorrect statement in OAuth::Cmdline
-    ( thanks Blaine Motsinger)
+    (thanks Blaine Motsinger)
     - Add LICENSE
-    ( thanks Mohammad S Anwar)
+    (thanks Mohammad S Anwar)
 
 0.06 (2016/11/11)
     (ms) Added support for Smartthings Web API

--- a/lib/OAuth/Cmdline.pm
+++ b/lib/OAuth/Cmdline.pm
@@ -257,7 +257,19 @@ sub tokens_get {
             $data->{ expires_in } );
     }
 
-    LOGDIE $resp->status_line();
+    my $error;
+    eval {
+        my $json = $resp->content();
+        DEBUG "Received: [$json]",
+        my $data = from_json( $json );
+        $error = $data->{'error'};
+    };
+    # An exception will be thrown if the content is not JSON
+    if ($@) {
+        $error = $resp->content();
+    }
+
+    LOGDIE $resp->status_line() . ' - ' . $error . "\n";
     return undef;
 }
 


### PR DESCRIPTION
When Google responded with an error in response to a
token request, it was only throwing the status line
of the HTTP response.  We also want the actual error
supplied in the content of the response.

(cherry picked from commit b923b2e3e144ec3f6fa975358c747e269a4ef70b)
Signed-off-by: Nicolas R <nicolas@atoomic.org>